### PR TITLE
Implement anthy_set_logger

### DIFF
--- a/anthy/xchar.h
+++ b/anthy/xchar.h
@@ -1,6 +1,6 @@
 /* 各種カナや文字のコードと識別関数 */
 #ifndef _xchar_h_included_
-#define _xhcar_h_included_
+#define _xchar_h_included_
 
 #include <anthy/xstr.h>
 


### PR DESCRIPTION
While are trying to port Anthy (actually [fcitx5-anthy](https://github.com/fcitx/fcitx5-anthy)) to Android ([fcitx5-android](https://github.com/fcitx5-android/fcitx5-android)), I noticed that `anthy_set_logger` has no effect. A quick looking through to the code, I found it is `/* to be implemented */`. So I wrote a simple Implemention, alloc a buffer to save log string, then pass it to the logger function.