### PR TITLE
Port to meson

### DIFF
--- a/anthy/meson.build
+++ b/anthy/meson.build
@@ -1,0 +1,7 @@
+install_headers([
+    'anthy.h',
+    'dicutil.h',
+    'input.h',
+  ],
+  subdir: meson.project_name()+'-1.0' / 'anthy'
+)

--- a/calctrans/meson.build
+++ b/calctrans/meson.build
@@ -1,0 +1,27 @@
+calctrans_sources = [
+  'calctrans.c',
+  'input_set.c',
+  'corpus.c',
+]
+
+proccorpus_sources = [
+  'proccorpus.c',
+]
+
+calctrans = executable('calctrans',
+  sources: calctrans_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+)
+
+proccorpus = executable('proccorpus',
+  sources: calctrans_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+)
+
+anthy_transition_matrix = custom_target('anthy.[cand_info|trans_info|corpus_array|corpus_bucket|weak_words]',
+  input: ['corpus_info', 'weak_words'],
+  output: ['anthy.cand_info', 'anthy.trans_info', 'anthy.corpus_array', 'anthy.corpus_bucket', 'anthy.weak_words'],
+  command: [calctrans, '-c', '@INPUT0@', '@INPUT1@', '-d', meson.current_build_dir()],
+)

--- a/depgraph/meson.build
+++ b/depgraph/meson.build
@@ -1,0 +1,11 @@
+mkdepgraph = executable('mkdepgraph',
+  sources: ['mkdepgraph.c'],
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+  c_args: '-DSRCDIR="'+meson.current_source_dir()+'"',
+)
+
+anthy_dep_graph = custom_target('anthy.dep',
+  output: ['anthy.dep'],
+  command: [mkdepgraph, '-o', '@OUTPUT0@'],
+)

--- a/depgraph/mkdepgraph.c
+++ b/depgraph/mkdepgraph.c
@@ -477,8 +477,10 @@ write_file(const char* file_name)
 }
 
 int 
-main(void)
+main(int argc, char **argv)
 {
+  int i;
+  const char *out_fn = "anthy.dep";
   /* 付属語辞書を読み込んでファイルに書き出す */
   anthy_conf_override("CONFFILE", "../anthy-unicode.conf");
   anthy_conf_override("ANTHYDIR", SRCDIR "/../depgraph/");
@@ -490,7 +492,15 @@ main(void)
   /* 自立語からの遷移表 */
   init_indep_word_seq_tab();
 
-  write_file("anthy.dep");
+  for (i = 1; i < argc; i++) {
+    char *arg = argv[i];
+    char *prev_arg = argv[i-1];
+    if (!strcmp(prev_arg, "-o")) {
+      out_fn = arg;
+    }
+  }
+
+  write_file(out_fn);
 
   return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('anthy-unicode',
   ['c'],
-  version: '1.0.0.20240207',
+  version: '1.0.0.@0@'.format(run_command('date', '+%Y%m%d',
+                                          check: true).stdout().strip()),
   license: 'LGPL2.1+',
   meson_version: '>= 0.59',
 )
@@ -8,22 +9,27 @@ project('anthy-unicode',
 cc = meson.get_compiler('c')
 
 config_h = configuration_data()
-config_h.set('VERSION', '"'+meson.project_version()+'"')
-config_h.set('PACKAGE', '"'+meson.project_name()+'"')
+config_h.set('PACKAGE', '"@0@"'.format(meson.project_name()))
+config_h.set('VERSION', '"@0@"'.format(meson.project_version()))
 
 foreach a : ['strerror_r']
   if cc.has_function(a)
-    config_h.set('HAVE_'+a.to_upper(), 1,
-      description: 'Define to 1 if you have the `'+a+'\' function.')
+    config_h.set('HAVE_@0@'.format(a.to_upper()), 1,
+                 description:
+                   'Define to 1 if you have the `@0@\' function.'.format(a))
   endif
 endforeach
 
 configure_file(output: 'config.h', configuration: config_h)
-add_project_arguments('-DCONF_DIR="'+get_option('sysconfdir')+'"', language : 'c')
+add_project_arguments(
+  '-DCONF_DIR="@0@"'.format(get_option('sysconfdir')),
+  language : 'c'
+)
 
 if get_option('emacs').allowed()
   if get_option('emacs_path') != ''
-    emacs = find_program(get_option('emacs_path'), required: get_option('emacs').enabled())
+    emacs = find_program(get_option('emacs_path'),
+                         required: get_option('emacs').enabled())
   else
     emacs = find_program('emacs', required: get_option('emacs').enabled())
   endif
@@ -77,9 +83,9 @@ subdir('test')
 #subdir('alt-cannadic')
 
 anthy_conf = configuration_data()
-anthy_conf.set('VERSION', meson.project_version())
 anthy_conf.set('PACKAGE', meson.project_name())
-anthy_conf.set('datadir', '${prefix}' / get_option('datadir'))
+anthy_conf.set('VERSION', meson.project_version())
+anthy_conf.set('datadir', get_option('prefix') / get_option('datadir'))
 anthy_conf.set('prefix', get_option('prefix'))
 configure_file(
   input: 'anthy-unicode.conf.in',
@@ -90,11 +96,11 @@ configure_file(
 )
 
 anthy_unicode_pc = configuration_data()
+anthy_unicode_pc.set('PACKAGE', meson.project_name())
+anthy_unicode_pc.set('VERSION', meson.project_version())
 anthy_unicode_pc.set('prefix', get_option('prefix'))
 anthy_unicode_pc.set('includedir', '${prefix}' / get_option('includedir'))
 anthy_unicode_pc.set('libdir', '${exec_prefix}' / get_option('libdir'))
-anthy_unicode_pc.set('PACKAGE', meson.project_name())
-anthy_unicode_pc.set('VERSION', meson.project_version())
 configure_file(
   input: 'anthy-unicode.pc.in',
   output: 'anthy-unicode.pc',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,104 @@
+project('anthy-unicode',
+  ['c'],
+  version: '1.0.0.20240207',
+  license: 'LGPL2.1+',
+  meson_version: '>= 0.59',
+)
+
+cc = meson.get_compiler('c')
+
+config_h = configuration_data()
+config_h.set('VERSION', '"'+meson.project_version()+'"')
+config_h.set('PACKAGE', '"'+meson.project_name()+'"')
+
+foreach a : ['strerror_r']
+  if cc.has_function(a)
+    config_h.set('HAVE_'+a.to_upper(), 1,
+      description: 'Define to 1 if you have the `'+a+'\' function.')
+  endif
+endforeach
+
+configure_file(output: 'config.h', configuration: config_h)
+add_project_arguments('-DCONF_DIR="'+get_option('sysconfdir')+'"', language : 'c')
+
+if get_option('emacs').allowed()
+  if get_option('emacs_path') != ''
+    emacs = find_program(get_option('emacs_path'), required: get_option('emacs').enabled())
+  else
+    emacs = find_program('emacs', required: get_option('emacs').enabled())
+  endif
+else
+  emacs = find_program('', required: false)
+endif
+
+if get_option('lisp_dir') == ''
+  lispdir = ''
+  if emacs.found()
+    r = run_command(emacs,
+      '-batch',
+      '-Q',
+      '-eval',
+      '\'(while load-path (princ (concat (car load-path) "\n")) (setq load-path (cdr load-path)))\'',
+      '</dev/null',
+      check: true,
+    )
+
+    foreach path : r.stdout().split('/n')
+      if path.contains('emacs/site-lisp')
+        if path.contains('/lib/')
+          lispdir = get_option('libdir') / path.split('/lib/')[1]
+        elif path.contains('/share/')
+          lispdir = get_option('datadir') / path.split('/share/')[1]
+        endif
+      endif
+    endforeach
+  endif
+  if lispdir == ''
+    lispdir = get_option('datadir') / 'emacs' / 'site-lisp'
+  endif
+else
+  lispdir = get_option('lisp_dir')
+endif
+
+top_srcdir = include_directories('.')
+subdir('src-ordering')
+subdir('src-diclib')
+subdir('src-splitter')
+subdir('src-worddic')
+subdir('src-main')
+subdir('src-util')
+subdir('anthy')
+subdir('depgraph')
+subdir('mkworddic')
+subdir('calctrans')
+subdir('mkanthydic')
+subdir('test')
+#subdir('doc')
+#subdir('alt-cannadic')
+
+anthy_conf = configuration_data()
+anthy_conf.set('VERSION', meson.project_version())
+anthy_conf.set('PACKAGE', meson.project_name())
+anthy_conf.set('datadir', '${prefix}' / get_option('datadir'))
+anthy_conf.set('prefix', get_option('prefix'))
+configure_file(
+  input: 'anthy-unicode.conf.in',
+  output: 'anthy-unicode.conf',
+  configuration: anthy_conf,
+  install: true,
+  install_dir: get_option('sysconfdir')
+)
+
+anthy_unicode_pc = configuration_data()
+anthy_unicode_pc.set('prefix', get_option('prefix'))
+anthy_unicode_pc.set('includedir', '${prefix}' / get_option('includedir'))
+anthy_unicode_pc.set('libdir', '${exec_prefix}' / get_option('libdir'))
+anthy_unicode_pc.set('PACKAGE', meson.project_name())
+anthy_unicode_pc.set('VERSION', meson.project_version())
+configure_file(
+  input: 'anthy-unicode.pc.in',
+  output: 'anthy-unicode.pc',
+  configuration: anthy_unicode_pc,
+  install: true,
+  install_dir: get_option('libdir') / 'pkgconfig'
+)

--- a/meson.build
+++ b/meson.build
@@ -108,3 +108,5 @@ configure_file(
   install: true,
   install_dir: get_option('libdir') / 'pkgconfig'
 )
+
+meson.add_dist_script('meson_dist.py')

--- a/meson_dist.py
+++ b/meson_dist.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python3
+# vim:set fileencoding=utf-8 et sts=4 sw=4:
+#
+# anthy-unicode - Anthy is a library for Japanese text input.
+#
+# Copyright © 2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# Set the previous anthy-unicode version from `git tag -l` command.
+ANTHY_PREV_VERSION = os.getenv('ANTHY_PREV_VERSION')
+ANTHY_PREV_DATE='20190412'
+BUILD_ROOT = os.getenv('MESON_PROJECT_BUILD_ROOT', '.')
+SOURCE_ROOT = os.getenv('MESON_PROJECT_SOURCE_ROOT', '.')
+DIST_ROOT = os.getenv('MESON_PROJECT_DIST_ROOT', '.')
+
+cmd = ['meson', 'introspect', '--projectinfo', BUILD_ROOT]
+info = None
+try:
+    result = subprocess.run(cmd, text=True, check=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            cwd=BUILD_ROOT).stdout
+    info = json.loads(result)
+except subprocess.CalledProcessError as e:
+    print(f'Failed to run meson introspect: {e}', file=sys.stderr)
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f'Failed to decode JSON from meson introspect: {e}',
+          file=sys.stderr)
+    sys.exit(1)
+
+os.chdir(SOURCE_ROOT)
+if not os.path.isdir('.git'):
+    print(f'{SOURCE_ROOT}/.git is not a directory', file=sys.stderr)
+    sys.exit(0)
+
+name_str = info.get('descriptive_name')
+version_str = info.get('version')
+if name_str == None or version_str == None:
+    print(f'You should run meson setup {BUILD_ROOT}', file=sys.stderr)
+    sys.exit(1)
+
+versions = version_str.split('.')
+major_version = int(versions[0])
+minor_version = int(versions[1])
+micro_version = int(versions[2])
+if ANTHY_PREV_VERSION == None:
+    prev_micro_version_str = ''
+    if micro_version > 0:
+        prev_micro_version = micro_version - 1
+        prev_micro_version_str = '%d' % prev_micro_version
+    else:
+        # Set the fixed tag until the official version is available.
+        prev_micro_version_str = '%d.%s' % (micro_version, ANTHY_PREV_DATE)
+    ANTHY_PREV_VERSION = '%d.%d.%s' % (major_version,
+                                       minor_version,
+                                       prev_micro_version_str)
+subprocess.run('git log --name-status --date=iso > "{0}/{1}"'.format(
+               DIST_ROOT, 'ChangeLog'),
+               shell = True)
+subprocess.run('echo "Changes in {0} {1} " > "{2}/{3}"'.format(
+               name_str, version_str,
+               DIST_ROOT, 'NEWS'),
+               shell = True)
+subprocess.run('echo "" >> "{0}/{1}"'.format(
+               DIST_ROOT, 'NEWS'),
+               shell = True)
+subprocess.run('git shortlog {0}...{1} >> "{2}/{3}"'.format(
+               ANTHY_PREV_VERSION, version_str,
+               DIST_ROOT, 'NEWS'),
+               shell = True)
+subprocess.run('echo "" >> "{0}/{1}"'.format(
+               DIST_ROOT, 'NEWS'),
+               shell = True)
+subprocess.run('git log {0}...{1} {2} >> "{3}/{4}"'.format(
+               ANTHY_PREV_VERSION, version_str,
+               '--reverse --pretty=format:"%s (%an) %h"',
+               DIST_ROOT, 'NEWS'),
+               shell = True)
+
+shutil.copy2('autogen.sh', f'{DIST_ROOT}')
+# Do you wish to copy configure and Makefile.in ?

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,17 @@
+option('emacs',
+  type: 'feature',
+  value: 'auto',
+  description: 'enable or disable compiling lip files using emacs'
+)
+
+option('emacs_path',
+  type: 'string',
+  value: '',
+  description: 'path to emacs command for compiling lisp files'
+)
+
+option('lisp_dir',
+  type: 'string',
+  value: '',
+  description: 'path to emacs lisp-site install directory'
+)

--- a/mkanthydic/meson.build
+++ b/mkanthydic/meson.build
@@ -1,0 +1,13 @@
+mkfiledic = executable('mkfiledic',
+  sources: 'mkfiledic.c',
+  include_directories: [top_srcdir],
+  dependencies: [diclib_dep],
+)
+
+anthy_word_dic = custom_target('anthy.dic',
+  input: [ anthy_word_dic, anthy_dep_graph, anthy_transition_matrix],
+  output: ['anthy.dic'],
+  command: [mkfiledic, '-p', meson.project_build_root(), '-o', '@OUTPUT0@'],
+  install: true,
+  install_dir: get_option('datadir') / meson.project_name(),
+)

--- a/mkanthydic/mkfiledic.c
+++ b/mkanthydic/mkfiledic.c
@@ -207,6 +207,7 @@ main(int argc, char* argv[])
   int i;
   const char *prefix = "..";
   const char *prev_arg = "";
+  const char *dic_out  = DIC_NAME;
 
   struct header_entry entries[] = {
     {"word_dic", "/mkworddic/anthy.wdic"},
@@ -222,12 +223,15 @@ main(int argc, char* argv[])
     if (!strcmp("-p", prev_arg)) {
       prefix = argv[i];
     }
+    if (!strcmp("-o", prev_arg)) {
+      dic_out = argv[i];
+    }
     /**/
     prev_arg = argv[i];
   }
   printf("file name prefix=[%s] you can change this by -p option.\n", prefix);
 
-  create_file_dic(DIC_NAME, prefix,
+  create_file_dic(dic_out, prefix,
 		  sizeof(entries)/sizeof(struct header_entry),
 		  entries);
 

--- a/mkworddic/meson.build
+++ b/mkworddic/meson.build
@@ -1,0 +1,24 @@
+mkworddic_sources = [
+  'mkdic.c',
+  'writewords.c',
+  'mkudic.c',
+  'calcfreq.c',
+]
+
+mkworddic = executable('mkworddic',
+  sources: mkworddic_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+)
+
+dict_args_conf = configuration_data()
+dict_args_conf.set('top_srcdir', meson.project_source_root())
+dict_args = configure_file(input: 'dict.args.in', output: 'dict.args', configuration: dict_args_conf)
+
+anthy_word_dic = custom_target('anthy.wdic',
+  input: [dict_args],
+  output: ['anthy.wdic'],
+  command: [mkworddic, '-f', './@INPUT0@', '-o', '@OUTPUT0@'],
+)
+
+install_data('zipcode.t', install_dir : get_option('datadir') / meson.project_name())

--- a/mkworddic/mkdic.c
+++ b/mkworddic/mkdic.c
@@ -1174,10 +1174,10 @@ execute_batch(struct mkdic_stat *mds, const char *fn)
 
 /* 辞書生成のための変数の初期化 */
 static void
-init_mds(struct mkdic_stat *mds)
+init_mds(struct mkdic_stat *mds, char *output)
 {
   int i;
-  mds->output_fn = DEFAULT_FN;
+  mds->output_fn = output;
   mds->ud = NULL;
 
   /* 単語辞書を初期化する */
@@ -1239,12 +1239,9 @@ main(int argc, char **argv)
   struct mkdic_stat mds;
   int i;
   char *script_fn = NULL;
+  char *out_fn = DEFAULT_FN;
   int help_mode = 0;
   int retval;
-
-  anthy_init_wtypes();
-  init_libs();
-  init_mds(&mds);
 
   for (i = 1; i < argc; i++) {
     char *arg = argv[i];
@@ -1255,11 +1252,18 @@ main(int argc, char **argv)
     if (!strcmp(prev_arg, "-f")) {
       script_fn = arg;
     }
+    if (!strcmp(prev_arg, "-o")) {
+      out_fn = arg;
+    }
   }
 
   if (help_mode || !script_fn) {
     print_usage();
   }
+
+  anthy_init_wtypes();
+  init_libs();
+  init_mds(&mds, out_fn);
 
   retval = execute_batch(&mds, script_fn);
   free_yomi_entry_list(&mds.yl);

--- a/src-diclib/conf.c
+++ b/src-diclib/conf.c
@@ -250,7 +250,8 @@ anthy_do_conf_init(void)
       add_val("CONFFILE", CONF_DIR"/anthy-unicode.conf");
     }
     pw = getpwuid(getuid());
-    add_val("HOME", pw->pw_dir);
+    if (pw)
+      add_val("HOME", pw->pw_dir);
     alloc_session_id();
     read_conf_file();
     confIsInit = 1;

--- a/src-diclib/meson.build
+++ b/src-diclib/meson.build
@@ -1,0 +1,18 @@
+libdiclib_sources = [
+  'diclib.c',
+  'file_dic.c',
+  'filemap.c',
+  'xstr.c',
+  'xchar.c',
+  'alloc.c',
+  'conf.c',
+  'logger.c',
+  'ruleparser.c',
+]
+
+libdiclib = static_library('diclib',
+  sources: libdiclib_sources,
+  include_directories: [top_srcdir],
+)
+
+diclib_dep = declare_dependency(link_with: libdiclib)

--- a/src-main/meson.build
+++ b/src-main/meson.build
@@ -1,0 +1,14 @@
+libanthy_sources = [
+  'main.c',
+  'context.c',
+]
+
+libanthy_unicode = library('anthy-unicode',
+  sources: libanthy_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthydic_dep, ordering_dep, split_dep],
+  version: '0.1.0',
+  install: true,
+)
+
+anthy_dep = declare_dependency(link_with: libanthy_unicode)

--- a/src-ordering/meson.build
+++ b/src-ordering/meson.build
@@ -1,0 +1,15 @@
+libordering_sources = [
+  'candswap.c',
+  'candsort.c',
+  'commit.c',
+  'relation.c',
+  'infosort.c',
+  'candhistory.c',
+]
+
+libordering = static_library('ordering',
+  sources: libordering_sources,
+  include_directories: [top_srcdir],
+)
+
+ordering_dep = declare_dependency(link_with: libordering)

--- a/src-splitter/meson.build
+++ b/src-splitter/meson.build
@@ -1,0 +1,18 @@
+libsplit_sources = [
+  'wordlist.c',
+  'metaword.c',
+  'depgraph.c',
+  'splitter.c',
+  'evalborder.c',
+  'compose.c',
+  'lattice.c',
+  'segclass.c',
+]
+
+libsplit = static_library('split',
+  sources: libsplit_sources,
+  include_directories: [top_srcdir],
+  dependencies: [diclib_dep, cc.find_library('m', required: false)]
+)
+
+split_dep = declare_dependency(link_with: libsplit)

--- a/src-util/meson.build
+++ b/src-util/meson.build
@@ -1,0 +1,87 @@
+libanthyinput_sources = [
+  'input.c',
+  'rkconv.c',
+  'rkhelper.c',
+]
+
+anthy_agent_sources = [
+  'agent.c',
+  'egg.c',
+]
+
+elisp_sources = [
+  'anthy-unicode.el',
+  'anthy-unicode-azik.el',
+  'anthy-unicode-conf.el',
+  'anthy-unicode-dic.el',
+  'anthy-unicode-isearch.el',
+  'anthy-unicode-kyuri.el',
+  'leim-list.el',
+]
+
+libconvdb = static_library('convdb',
+  sources: 'convdb.c',
+  include_directories: [top_srcdir],
+)
+
+libanthyinput = library('anthyinput-unicode',
+  sources: libanthyinput_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+  version: '0.0.0',
+  install: true,
+)
+
+convdb_dep     = declare_dependency(link_with: libconvdb)
+anthyinput_dep = declare_dependency(link_with: libanthyinput)
+
+anthy_dic_tool = executable('anthy-dic-tool-unicode',
+  sources: 'dic-tool.c',
+  include_directories: [top_srcdir],
+  dependencies: [anthydic_dep],
+  install: true,
+)
+
+anthy_agent = executable('anthy-agent-unicode',
+  sources: anthy_agent_sources,
+  include_directories: [top_srcdir],
+  dependencies: [anthyinput_dep, anthy_dep, anthydic_dep],
+  install: true,
+)
+
+anthy_morpholigical_analyzer = executable('anthy-morphological-analyzer-unicode',
+  sources: 'morph-main.c',
+  include_directories: [top_srcdir],
+  dependencies: [convdb_dep, anthy_dep, anthydic_dep],
+  install: true,
+)
+
+install_data('typetab', install_dir : get_option('datadir') / meson.project_name())
+install_data('dic-tool-usage.txt', install_dir : get_option('datadir') / meson.project_name())
+
+foreach src : elisp_sources
+  install_data(src, install_dir : lispdir / 'anthy-unicode')
+
+  if emacs.found() and src != 'leim-list.el'
+    target_name = src.split('.')[0] + '.elc'
+    target_path = meson.current_build_dir() / target_name
+    target_func = '(setq byte-compile-dest-file-function (lambda (_) "' + target_path + '"))'
+    custom_target(target_name,
+      input: src,
+      output: target_name,
+      install_dir: lispdir / 'anthy-unicode',
+      install: true,
+      # rebuild all if any changed.
+      depend_files: elisp_sources,
+      command: [emacs,
+        '--no-init-file',
+        '--batch',
+        '--directory', meson.current_source_dir(),
+        '--directory', meson.current_build_dir(),
+        '--eval', target_func,
+        '--funcall', 'batch-byte-compile',
+        '@INPUT@'
+      ]
+    )
+  endif
+endforeach

--- a/src-worddic/meson.build
+++ b/src-worddic/meson.build
@@ -1,0 +1,25 @@
+libanthydic_sources = [
+  'word_dic.c',
+  'dic_util.c',
+  'wtype.c',
+  'texttrie.c',
+  'textdict.c',
+  'record.c',
+  'word_lookup.c',
+  'use_dic.c',
+  'priv_dic.c',
+  'mem_dic.c',
+  'ext_ent.c',
+  'matrix.c',
+  'feature_set.c',
+]
+
+libanthydic_unicode = library('anthydic-unicode',
+  sources: libanthydic_sources,
+  include_directories: [top_srcdir],
+  dependencies: [diclib_dep],
+  version: '0.1.0',
+  install: true,
+)
+
+anthydic_dep = declare_dependency(link_with: libanthydic_unicode)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,32 @@
+anthy = executable('anthy',
+  sources: 'main.c',
+  include_directories: [top_srcdir],
+  dependencies: [convdb_dep, anthy_dep, anthydic_dep],
+  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+)
+
+checklib = executable('checklib',
+  sources: 'check.c',
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+)
+
+prediction = executable('prediction',
+  sources: 'prediction.c',
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+)
+
+test_matrix = executable('test-matrix',
+  sources: 'test-matrix.c',
+  include_directories: [top_srcdir],
+  dependencies: [anthy_dep, anthydic_dep],
+  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+)
+
+test('Main anthy tests', anthy, args: ['--all'])
+test('Library load tests', checklib)
+test('Anthy prediction tests', prediction)
+test('Anthy matrix tests', test_matrix)


### PR DESCRIPTION
If there is not interest in this, feel free to let me know.

I decided to do this as libtool/autoconf was giving me a lot of trouble with cross compiling and there isn't really a good way to do both native and cross compiling due to how the dependencies work.
This makes cross compiling much easier as meson supports an `exe_wrapper` command which can be set to, for example, qemu.

I verified that the same files get outputted with both this and autoconf (except for the .la files which shouldn't be installed anyway, and the .a files, which can be enabled in meson with `-Ddefault_library=both` if so desired. meson by default uses the equivalent of `--disable-static`):
https://gist.github.com/oreo639/cd4d3c53d8bc4d90203d647debb53dbd
(confls is autoconf and mesonls is meson)

I also verified that the resulting package can be installed and works correctly (and can be used to build ibus-anthy and fcitx-anthy).

I didn't implement `update_params`/`update_params0`/`update_params2` since I'm not sure how you want to handle those. ([fujiwarat/anthy-unicode/calctrans/Makefile.am](https://github.com/fujiwarat/anthy-unicode/blob/360c112cff27fe82fff07bb255a48e40ab7a0849/calctrans/Makefile.am#L16-L39))
Let me know if I missed anything.
I didn't add meson to the autoconf dist, if that is something you want me to do, let me know. (meson dist works by pulling the files from git so it should be fine on that side)

I also added a fix for crashing when `getpwuid()` returns null when cross compiling (due to `add_val("HOME", pw->pw_dir);` trying to dereference a null ptr). I made it such that if `getpwuid()` returns null, HOME doesn't get added to the dictionary. I'm not sure how desirable this is. diclib should still be able to fallback on `getenv()` when that is the case, however if you have other suggestions, let me know.

Of course, let me know if I missed something.