### PR TITLE
meson: Fix anthy-unicode.conf search path in mkdepgraph

### DIFF
--- a/depgraph/meson.build
+++ b/depgraph/meson.build
@@ -2,7 +2,8 @@ mkdepgraph = executable('mkdepgraph',
   sources: ['mkdepgraph.c'],
   include_directories: [top_srcdir],
   dependencies: [anthy_dep, anthydic_dep],
-  c_args: '-DSRCDIR="'+meson.current_source_dir()+'"',
+  c_args: [ '-DBLDDIR="@0@"'.format(meson.current_build_dir()),
+            '-DSRCDIR="@0@"'.format(meson.current_source_dir()) ],
 )
 
 anthy_dep_graph = custom_target('anthy.dep',

--- a/depgraph/mkdepgraph.c
+++ b/depgraph/mkdepgraph.c
@@ -39,6 +39,10 @@
 #include <anthy/depgraph.h>
 #include <anthy/diclib.h>
 
+#ifndef BLDDIR
+#define BLDDIR "."
+#endif
+
 #ifndef SRCDIR
 #define SRCDIR "."
 #endif
@@ -482,7 +486,7 @@ main(int argc, char **argv)
   int i;
   const char *out_fn = "anthy.dep";
   /* 付属語辞書を読み込んでファイルに書き出す */
-  anthy_conf_override("CONFFILE", "../anthy-unicode.conf");
+  anthy_conf_override("CONFFILE", BLDDIR "/../anthy-unicode.conf");
   anthy_conf_override("ANTHYDIR", SRCDIR "/../depgraph/");
 
   anthy_init_wtypes();


### PR DESCRIPTION
Resolves issue where a blank anthy.dep is generated when using the meson build system. This is due to the anthy-unicode.conf path not being adjusted between meson and autotools.

BUG=#14