### PR TITLE
Improve test reporting with meson

### DIFF
--- a/test/check.c
+++ b/test/check.c
@@ -16,8 +16,8 @@ init(void)
   anthy_conf_override("DIC_FILE", "../mkanthydic/anthy.dic");
   res = anthy_init();
   if (res) {
-    printf("failed to init\n");
-    return 1;
+    fprintf(stderr, "failed to init\n");
+    return EXIT_FAILURE;
   }
   anthy_quit();
   /* init again */
@@ -26,10 +26,10 @@ init(void)
   anthy_conf_override("DIC_FILE", "../mkanthydic/anthy.dic");
   res = anthy_init();
   if (res) {
-    printf("failed to init\n");
-    return 1;
+    fprintf(stderr, "failed to init\n");
+    return EXIT_FAILURE;
   }
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 static int
@@ -38,11 +38,11 @@ test0(void)
   anthy_context_t ac;
   ac = anthy_create_context();
   if (!ac) {
-    printf("failed to create context\n");
-    return 1;
+    fprintf(stderr, "failed to create context\n");
+    return EXIT_FAILURE;
   }
   anthy_release_context(ac);
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 static int
@@ -53,8 +53,8 @@ test1(void)
   xstr *xs, *xs2;
   ac = anthy_create_context();
   if (!ac) {
-    printf("failed to create context\n");
-    return 1;
+    fprintf(stderr, "failed to create context\n");
+    return EXIT_FAILURE;
   }
   anthy_context_set_encoding (ac, ANTHY_UTF8_ENCODING);
   anthy_xstr_set_print_encoding (ANTHY_UTF8_ENCODING);
@@ -77,7 +77,7 @@ test1(void)
   anthy_putxstrln(xs2);
   anthy_free_xstr(xs);
   anthy_free_xstr(xs2);
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 /* compliant_rand:
@@ -90,7 +90,7 @@ compliant_rand(void)
 {
   struct timespec ts = { 0, };
   if (!timespec_get (&ts, TIME_UTC)) {
-    printf("Failed timespec_get\n");
+    fprintf(stderr, "Failed timespec_get\n");
     assert(0);
   }
   return ts.tv_nsec;
@@ -103,8 +103,8 @@ shake_test(const char *str)
   anthy_context_t ac;
   ac = anthy_create_context();
   if (!ac) {
-    printf("failed to create context\n");
-    return 1;
+    fprintf(stderr, "failed to create context\n");
+    return EXIT_FAILURE;
   }
   anthy_context_set_encoding(ac, ANTHY_UTF8_ENCODING);
   anthy_set_string(ac, str);
@@ -117,28 +117,33 @@ shake_test(const char *str)
     anthy_resize_segment(ac, nth, rsz);
   }
   anthy_release_context(ac);
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 int
 main(int argc, char **argv)
 {
+  int ret;
   (void)argc;
   (void)argv;
+  ret = EXIT_SUCCESS;
   printf("checking\n");
   if (init()) {
-    printf("fail (init)\n");
-    return 0;
+    fprintf(stderr, "fail (init)\n");
+    return EXIT_FAILURE;
   }
   if (test0()) {
-    printf("fail (test0)\n");
+    fprintf(stderr, "fail (test0)\n");
+    ret = EXIT_FAILURE;
   }
   if (test1()) {
-    printf("fail (test1)\n");
+    fprintf(stderr, "fail (test1)\n");
+    ret = EXIT_FAILURE;
   }
   if (shake_test("あいうえおかきくけこ")) {
-    printf("fail (shake_test)\n");
+    fprintf(stderr, "fail (shake_test)\n");
+    ret = EXIT_FAILURE;
   }
   printf("done\n");
-  return 0;
+  return ret;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -105,7 +105,7 @@ check_cond(struct condition *cond, struct input *in)
 static void
 log_print(int lv, const char *msg)
 {
-  printf("log:%d:%s\n", lv, msg);
+  fprintf(stderr, "log:%d:%s\n", lv, msg);
 }
 
 static anthy_context_t
@@ -118,8 +118,8 @@ init_lib(int use_utf8)
   anthy_conf_override("DIC_FILE", "../mkanthydic/anthy.dic");
   anthy_set_logger(log_print, 0);
   if (anthy_init()) {
-    printf("failed to init anthy\n");
-    exit(0);
+    fprintf(stderr, "failed to init anthy\n");
+    exit(EXIT_FAILURE);
   }
   anthy_set_personality("");
 
@@ -303,7 +303,7 @@ save_db(const char *fn, struct res_db *db)
   FILE *fp = fopen(fn, "w");
   struct conv_res *cr;
   if (!fp) {
-    printf("failed to open (%s) to write\n", fn);
+    fprintf(stderr, "failed to open (%s) to write\n", fn);
     return ;
   }
   for (cr = db->res_list.next; cr; cr = cr->next) {
@@ -394,8 +394,8 @@ main(int argc,char **argv)
 
   fp = fopen(testdata, "r");
   if (!fp) {
-    printf("failed to open %s.\n", testdata);
-    return 0;
+    fprintf(stderr, "failed to open %s.\n", testdata);
+    return EXIT_FAILURE;
   }
   free(testdata);
   
@@ -429,5 +429,5 @@ main(int argc,char **argv)
   show_stat(db);
   save_db(expdata, db);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,32 +1,46 @@
+test_c_args = ['-DSRCDIR="@0@"'.format(meson.current_source_dir()),
+               '-DTEST_HOME="@0@"'.format(meson.current_build_dir())]
+
 anthy = executable('anthy',
   sources: 'main.c',
   include_directories: [top_srcdir],
   dependencies: [convdb_dep, anthy_dep, anthydic_dep],
-  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+  c_args: test_c_args,
 )
 
 checklib = executable('checklib',
   sources: 'check.c',
   include_directories: [top_srcdir],
   dependencies: [anthy_dep, anthydic_dep],
-  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+  c_args: test_c_args,
 )
 
 prediction = executable('prediction',
   sources: 'prediction.c',
   include_directories: [top_srcdir],
   dependencies: [anthy_dep, anthydic_dep],
-  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+  c_args: test_c_args,
 )
 
 test_matrix = executable('test-matrix',
   sources: 'test-matrix.c',
   include_directories: [top_srcdir],
   dependencies: [anthy_dep, anthydic_dep],
-  c_args: ['-DSRCDIR="'+meson.current_source_dir()+'"', '-DTEST_HOME="'+meson.current_build_dir()+'"'],
+  c_args: test_c_args,
 )
 
-test('Main anthy tests', anthy, args: ['--all'])
-test('Library load tests', checklib)
-test('Anthy prediction tests', prediction)
-test('Anthy matrix tests', test_matrix)
+test('Main anthy tests', anthy,
+  args: ['--all'],
+  workdir: meson.current_build_dir(),
+  depends: [ anthy_word_dic ]
+)
+test('Library load tests', checklib,
+  workdir: meson.current_build_dir(),
+  depends: [ anthy_word_dic ]
+)
+#test('Anthy prediction tests', prediction,
+#  args: ['わ'],
+#  workdir: meson.current_build_dir(),
+#  depends: [ anthy_word_dic, anthy_dep_graph ]
+#)
+test('Anthy matrix tests', test_matrix, workdir: meson.current_build_dir())

--- a/test/prediction.c
+++ b/test/prediction.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <anthy/anthy.h>
+#include <anthy/xstr.h>
 
 
 /* Makefile の $(srcdir) (静的データファイルの基準ディレクトリ) */
@@ -18,8 +19,8 @@ init_lib(void)
   anthy_conf_override("DIC_FILE", "../mkanthydic/anthy.dic");
   anthy_conf_override("ANTHYDIR", SRCDIR "/../depgraph");
   if (anthy_init()) {
-    printf("failed to init anthy\n");
-    exit(0);
+    fprintf(stderr, "failed to init anthy\n");
+    exit(EXIT_FAILURE);
   }
 }
 
@@ -29,15 +30,32 @@ int main(int argc, char** argv)
   struct anthy_prediction_stat ps;
   anthy_context_t ac;
   int i;
+  int use_utf8;
 
   if (argc == 1) {
-    return 0;
+    fprintf(stderr, "no input string specified\n");
+    return EXIT_FAILURE;
   }
+  use_utf8 = 1;
   init_lib();
   ac = anthy_create_context();
+  if (!ac) {
+    fprintf(stderr, "failed to create context\n");
+    return EXIT_FAILURE;
+  }
+  if (use_utf8) {
+    anthy_context_set_encoding(ac, ANTHY_UTF8_ENCODING);
+    anthy_xstr_set_print_encoding(ANTHY_UTF8_ENCODING);
+  } else {
+    anthy_context_set_encoding(ac, ANTHY_EUC_JP_ENCODING);
+  }
 
   anthy_set_prediction_string(ac, argv[1]);
   anthy_get_prediction_stat(ac, &ps);
+  if (!ps.nr_prediction) {
+    fprintf(stderr, "no predictions found for %s\n", argv[1]);
+    return EXIT_FAILURE;
+  }
   for (i = 0; i < ps.nr_prediction; ++i) {
     char* buf;
     int len;


### PR DESCRIPTION
Currently, the tests always exit with 0, even when they encounter an error, this results in meson always treating the test as a success.
Notably, the tests don't run correctly with `meson test -C build --verbose`, since the CWDs aren't set correctly, this also fixes that.

Keep in mind that meson still reports success despite https://github.com/fujiwarat/anthy-unicode/issues/14 since the test itself doesn't error, although I can look into updating or adding a test for that later.

The prediction test is currently commented out since it relies on predictions in `~/.config/anthy` (it is still built though).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Redirected test diagnostics and errors to standard error and standardized exit codes for clearer CI feedback.
  * Strengthened test failure handling with stricter validation and explicit failure propagation across test suites.
* **Chores**
  * Unified test build configuration to reuse shared compilation arguments and clarified test invocation/workdir settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->