### PR TITLE
anthy-unicode.el: fix version check for Emacs 23+

### DIFF
--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -59,7 +59,7 @@
  "変換時の文節の区切りに使われる文字列")
 
 (defvar anthy-accept-timeout 50)
-(if (string-match "^22\." emacs-version)
+(if (>= emacs-major-version 22)
     (setq anthy-accept-timeout 1))
 
 (defconst anthy-working-buffer " *anthy*")


### PR DESCRIPTION
The current code only matches Emacs 22.x:

  (string-match "^22\\." emacs-version)

Use emacs-major-version instead.