### PR TITLE
src-util/anthy-unicode.el: 壊れている XEmacs 対応と undo の取り違えの修正

### DIFF
--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -559,14 +559,17 @@
 	  (char-to-string ch)
 	nil))))
 
-(defun anthy-restore-undo-list (commit-str)
-  (let* ((len (length commit-str))
-	 (beginning (point))
-	 (end (+ beginning len)))
-    (setq buffer-undo-list
-	  (cons (cons beginning end)
-		(cons nil anthy-saved-buffer-undo-list)))
-	 ))
+;; 呼び出し側も、anthy-saved-buffer-undo-list を設定する二箇所も、元から
+;; コメントアウトされている。この関数だけが生きていて、呼べば void-variable に
+;; なる。同じように閉じておく。
+;(defun anthy-restore-undo-list (commit-str)
+;  (let* ((len (length commit-str))
+;	 (beginning (point))
+;	 (end (+ beginning len)))
+;    (setq buffer-undo-list
+;	  (cons (cons beginning end)
+;		(cons nil anthy-saved-buffer-undo-list)))
+;	 ))
 
 (defun anthy-proc-agent-reply (repl)
   (let*

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -70,6 +70,14 @@
 (defvar anthy-agent-unicode-command-list '("anthy-agent-unicode")
   "anthy-agent-unicodeのPATH 名")
 
+;; XEmacs には set-process-query-on-exit-flag が無い。持っているのは
+;; process-kill-without-query で、第二引数 nil で「終了時に問い合わせない」
+;; になるのは同じ。
+(defvar anthy-set-process-no-query-function
+  (if (fboundp 'set-process-query-on-exit-flag)
+      'set-process-query-on-exit-flag
+    'process-kill-without-query))
+
 ;; face
 (defvar anthy-highlight-face nil)
 (defvar anthy-underline-face nil)
@@ -83,7 +91,12 @@
   (if (featurep 'xemacs)
       t nil))
 (if anthy-xemacs
-    (require 'overlay))
+    ;; overlay は XEmacs 本体には無く、fsf-compat package が持っている。
+    ;; 素の file-error では何を入れればよいか分からないので名前を言う。
+    (condition-case nil
+	(require 'overlay)
+      (error
+       (error "anthy-unicode: XEmacs needs the fsf-compat package for overlay"))))
 ;;
 (defvar anthy-mode-map nil
   "AnthyのASCIIモードのキーマップ")
@@ -752,7 +765,7 @@
 	(if anthy-agent-unicode-process
 	    (kill-process anthy-agent-unicode-process))
 	(setq anthy-agent-unicode-process proc)
-	(set-process-query-on-exit-flag proc nil)
+	(funcall anthy-set-process-no-query-function proc nil)
 ;;	(if anthy-xemacs
 ;;	    (if (coding-system-p (find-coding-system 'euc-japan))
 ;;		(set-process-coding-system proc 'euc-japan 'euc-japan))

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -85,6 +85,18 @@
       'set-process-query-on-exit-flag
     'process-kill-without-query))
 
+;; deactivate-* は Emacs 24.3 での改名。Emacs 23 以前と XEmacs は
+;; inactivate-* しか持たない。名前は二つ同時に変わったので、片方だけ
+;; 直しても症状は同じ。
+(defvar anthy-deactivate-input-method-function
+  (if (fboundp 'deactivate-input-method)
+      'deactivate-input-method
+    'inactivate-input-method))
+(defvar anthy-deactivate-current-input-method-variable
+  (if (boundp 'deactivate-current-input-method-function)
+      'deactivate-current-input-method-function
+    'inactivate-current-input-method-function))
+
 ;; face
 (defvar anthy-highlight-face nil)
 (defvar anthy-underline-face nil)
@@ -897,7 +909,8 @@
 ;; leim の activate
 ;;
 (defun anthy-unicode-leim-activate (&optional name)
-  (setq deactivate-current-input-method-function 'anthy-unicode-leim-inactivate)
+  (set anthy-deactivate-current-input-method-variable
+       'anthy-unicode-leim-inactivate)
   (setq anthy-leim-active-p t)
   (anthy-update-mode)
   (when (eq (selected-window) (minibuffer-window))
@@ -907,7 +920,7 @@
 ;; emacsのバグ避けらしいです
 ;;
 (defun anthy-unicode-leim-exit-from-minibuffer ()
-  (deactivate-input-method)
+  (funcall anthy-deactivate-input-method-function)
   (when (<= (minibuffer-depth) 1)
     (remove-hook 'minibuffer-exit-hook 'anthy-unicode-leim-exit-from-minibuffer)))
 

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -97,12 +97,18 @@
       'deactivate-current-input-method-function
     'inactivate-current-input-method-function))
 
+;; Emacs 24.3 までは set-face-underline-p の方が正で、set-face-underline は
+;; その obsolete な別名。24.3 で入れ替わる。XEmacs は -p しか持たない。
+(defvar anthy-set-face-underline-function
+  (if (fboundp 'set-face-underline)
+      'set-face-underline
+    'set-face-underline-p))
+
 ;; face
 (defvar anthy-highlight-face nil)
 (defvar anthy-underline-face nil)
 (copy-face 'highlight 'anthy-highlight-face)
-(if (not (featurep 'xemacs))
-    (set-face-underline 'anthy-highlight-face t))
+(funcall anthy-set-face-underline-function 'anthy-highlight-face t)
 (copy-face 'underline 'anthy-underline-face)
 
 ;;

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -1,4 +1,4 @@
-;;; anthy-unicode.el -- Anthy
+;;; anthy-unicode.el -- Anthy  -*- lexical-binding: nil -*-
 
 ;; Copyright (C) 2001 - 2007 KMC(Kyoto University Micro Computer Club)
 ;; Copyright (C) 2021 Takao Fujiwara <takao.fujiwara1@gmail.com>
@@ -69,6 +69,13 @@
 ;;
 (defvar anthy-agent-unicode-command-list '("anthy-agent-unicode")
   "anthy-agent-unicodeのPATH 名")
+
+;; XEmacs にしか無い名前。anthy-xemacs が真のときしか呼ばないが、直接書くと
+;; GNU Emacs の byte compiler が "not known to be defined" と言う。
+(defvar anthy-event-matches-key-specifier-p-function
+  'event-matches-key-specifier-p)
+(defvar anthy-event-to-character-function 'event-to-character)
+(defvar anthy-char-to-int-function 'char-to-int)
 
 ;; XEmacs には set-process-query-on-exit-flag が無い。持っているのは
 ;; process-kill-without-query で、第二引数 nil で「終了時に問い合わせない」
@@ -913,11 +920,12 @@
   (if anthy-xemacs
       (let ((event last-command-event))
 	(cond
-	 ((event-matches-key-specifier-p event 'left)      2)
-	 ((event-matches-key-specifier-p event 'right)     6)
-	 ((event-matches-key-specifier-p event 'backspace) 8)
+	 ((funcall anthy-event-matches-key-specifier-p-function event 'left)      2)
+	 ((funcall anthy-event-matches-key-specifier-p-function event 'right)     6)
+	 ((funcall anthy-event-matches-key-specifier-p-function event 'backspace) 8)
 	 (t
-	  (char-to-int (event-to-character event)))))
+	  (funcall anthy-char-to-int-function
+		   (funcall anthy-event-to-character-function event)))))
     last-command-event))
 
 ;;

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -215,6 +215,9 @@
 (anthy-deflocalvar anthy-current-rkmap "hiragana")
 ; undo
 (anthy-deflocalvar anthy-buffer-undo-list-saved nil)
+;; 待避した undo list そのもの。旗だけ buffer local で中身が global だったので、
+;; buffer を二つ使うと片方の履歴がもう片方のもので上書きされていた。
+(anthy-deflocalvar anthy-buffer-undo-list nil)
 
 ;;
 (defvar anthy-wide-space "　" "スペースを押した時に出て来る文字")


### PR DESCRIPTION
`src-util/anthy-unicode.el` の XEmacs 対応は 2019 年から壊れています。
あわせて、buffer を二つ使うと undo の履歴が入れ替わります。六本で
その二つを直します。

## XEmacs 対応

XEmacs は release が続いています。配布元の tarball の日付で、21.4.25 が
2026-01-01、21.5.36 が 2025-06-15 でした。両方を建てて測っています。

`src-util/anthy-unicode.el` は XEmacs を見ています。`anthy-xemacs` の分岐があり、
`anthy-last-command-char` に XEmacs 専用の枝があり、d9355d3 で
`set-face-underline` の当ても入れていただいています。

ところが現状、input method を立てた瞬間に止まります。

```
XEmacs 21.4.25 / 21.5.36
  Symbol's function definition is void: set-process-query-on-exit-flag
```

XEmacs はこの名前を持ちません。`anthy-check-agent` がこれを呼ぶので agent が
起こせず、**上に挙げた XEmacs 対応はどれも実行に到達しません。**

壊れたのは 2019 年です。fork 前の `anthy.el` は `process-kill-without-query` を
呼んでいて、XEmacs でも agent が起きます。その版を XEmacs 21.4.25 と 21.5.36 に
読ませて確かめました。

```
  30cb1a1  2013  (process-kill-without-query proc)          両方で動く
  4f737e0  2019  (process-query-on-exist-flag proc)         exit が exist。両方で止まる
  4493804  2021  (set-process-query-on-exit-flag proc nil)  GNU Emacs だけ戻る
```

一本目が `process-kill-without-query` を選べるようにします。第二引数が同じ意味の
裏返しで、nil を渡せばどちらも「訊かない」です。

もう一つ見つけたことがあります。`fsf-compat` package を入れていない XEmacs
では、そもそも file が読めません。

```
(file-error "Cannot open load file" "overlay")
```

`anthy-unicode.el` は XEmacs の枝で `(require 'overlay)` をしますが、`overlay` は
XEmacs 本体ではなく `fsf-compat` が持っています。何を入れればよいかすぐに分から
ないので、error に package 名を出すようにしています。検証中に自分が踏んで気づ
いたものです。file が読めなければ agent も起こせないので、一本目に入れてあり
ます。

起動するようになると、残りの取りこぼしが見えます。

**抜けられません。** `inactivate-*` から `deactivate-*` への改名は Emacs 24.3
で、XEmacs は旧名しか持ちません。`anthy-unicode-leim-activate` が `setq` で
`deactivate-current-input-method-function` を立てますが、XEmacs はそれを読まず、
`inactivate-current-input-method-function` は nil のまま。抜けるときに nil が
funcall されます。五本目が両方の名前を選ぶようにします。

**下線が付きません。** d9355d3 は XEmacs では呼ばない形なので、preedit の face に
下線が付きません。`set-face-underline-p` は XEmacs にも在るので、名前を選ぶ形に
すれば分岐ごと畳めます。六本目です。

## buffer をまたぐと undo の履歴が入れ替わる

こちらは版に関係ありません。`anthy-buffer-undo-list-saved` は
`anthy-deflocalvar` で buffer ごとなのに、肝心の `anthy-buffer-undo-list` は
宣言の無いただの global です。三文字の buffer A と四十文字の buffer B で順に
変換を始めると、

```
A で変換開始    anthy-buffer-undo-list = (nil (1 . 4) (t . 0))
B で変換開始    A の待避が            (nil (1 . 41) (t . 0)) に化ける
A で確定        (nil (4 . 8) nil (1 . 41) (t . 0))
```

末尾が 8 の buffer に「1 から 41 を消せ」という履歴が残ります。A で undo
すると別の buffer の編集を取り消そうとして、A の中身が壊れます。三本目が直します。

同じ節に、動かない経路を閉じる分 (二本目) も入れました。
`anthy-restore-undo-list` が読む `anthy-saved-buffer-undo-list` を設定する二箇所
も、その関数の唯一の呼び出しも、元からコメントアウトされています。関数だけが
生きていて、呼べば `void-variable` になります。anthy 9100h の anthy.el が同じ
状態なので、2009 年の release の時点でこうでした。消さずに、呼び出し側と同じ
ようにコメントアウトしてあります。

## pipe を UTF-8 にする件は別に出します

`anthy-agent-unicode` は UTF-8 でしか話しませんが、pipe の符号化は Emacs の
既定のまま、つまり利用者の locale 任せです。`LC_ALL=ja_JP.eucJP` で「nihongo」を
確定すると、上流でも六本を当てた後でも化けます。

```
  Emacs 31.1 30.2 29.4 28.2 27.2 24.5 23.4 22.3   六本の後も NG
  XEmacs 21.5.36                                  六本の後も NG
```

日本語だけの話ではありません。NetBSD 11.0/amd64 の Emacs 30.2 で、箱に在る
203 の locale をすべて掃くと 136 で化けました。近隣だけでもこれだけあります。

```
  ja  ja_JP.eucJP  ja_JP.SJIS  ja_JP.ct
  ko  ko_KR.eucKR
  zh_CN  zh_CN.eucCN  zh_CN.GB2312  zh_CN.GB18030
  zh_HK.Big5-HKSCS  zh_HK.Big5HKSCS  zh_HK.Big5hkscs
```

残る 123 は西欧・東欧・キリル文字などです。UTF-8 の locale なら Emacs 22 以降は
影響を受けません (Emacs 21.4 は UTF-8 でも化けます)。

当ては書いてありますが、この六本とは論点が別で、依存もありません
(`anthy-check-agent` に足すだけです)。別の PR にします。

## 測ったもの

NetBSD 11.0/amd64 で、pkgsrc から建てたものです。XEmacs は Mule 付きの build で、
`anthy-unicode.el` が `(require 'overlay)` をするので `fsf-compat` が要ります。
あわせて `mule-base` `xemacs-base` `edit-utils` を入れて走らせました。

グラフの左が対象、右は参考として測っただけの版です。本家が保守しているのは
31.1 だけですが、pkgsrc(NetBSD) は 29 以降を、Debian は oldstable で 28.2 を
いまも配っているので、そこまでを対象に測っています。XEmacs の列は 21.5.36 と
21.4.25 が同じ値でした。

byte-compile の警告:

```
                  XEmacs 31/30 29/28  | 27-24 23/22    21    20
  ------------------------------------+------------------------
  upstream             0     9     8  |     6     8     0     0
  1 process-kill       0     9     8  |     6     8     0     0
  2 dead path          0     8     7  |     5     7     0     0
  3 saved list         0     4     3  |     1     3     0     0
  4 compiler           0     0     0  |     0     3     0     0
  5 deactivate         0     0     0  |     0     1     0     0
  6 underline          0     0     0  |     0     0     0     0
```

undo の履歴が自分のものか:

```
                  XEmacs 31/30 29/28  | 27-24 23/22    21    20
  ------------------------------------+------------------------
  upstream             X    NG    NG  |    NG    NG     X     X
  1 process-kill      NG    NG    NG  |    NG    NG    NG     X
  2 dead path         NG    NG    NG  |    NG    NG    NG     X
  3 saved list        OK    OK    OK  |    OK    OK    OK     X
  4 compiler          OK    OK    OK  |    OK    OK    OK     X
  5 deactivate        OK    OK    OK  |    OK    OK    OK     X
  6 underline         OK    OK    OK  |    OK    OK    OK     X
```

input method から抜けられるか:

```
                  XEmacs 31/30 29/28  | 27-24 23/22    21    20
  ------------------------------------+------------------------
  upstream             X    OK    OK  |    OK    NG     X     X
  1 process-kill      NG    OK    OK  |    OK    NG    NG     X
  2 dead path         NG    OK    OK  |    OK    NG    NG     X
  3 saved list        NG    OK    OK  |    OK    NG    NG     X
  4 compiler          NG    OK    OK  |    OK    NG    NG     X
  5 deactivate        OK    OK    OK  |    OK    OK    OK     X
  6 underline         OK    OK    OK  |    OK    OK    OK    OK
```

preedit の face に下線が付くか:

```
                  XEmacs 31/30 29/28  | 27-24 23/22    21    20
  ------------------------------------+------------------------
  upstream           nil     t     t  |     t     t     t     X
  1 process-kill     nil     t     t  |     t     t     t     X
  2 dead path        nil     t     t  |     t     t     t     X
  3 saved list       nil     t     t  |     t     t     t     X
  4 compiler         nil     t     t  |     t     t     t     X
  5 deactivate       nil     t     t  |     t     t     t     X
  6 underline          t     t     t  |     t     t     t     t
```

XEmacs と Emacs 20/21 の警告が全段 0 なのは、その compiler が未定義の関数も
obsolete も報告しないためです。XEmacs で測れるのは挙動のほうです。

`X` はそこで止まって測れないところです。XEmacs 21.4/21.5 と Emacs 21.4 は
`void-function set-process-query-on-exit-flag`、Emacs 20.7 は
`void-function set-face-underline` です。

Emacs 20.7 は六本目で load が通り、下線と離脱もそこで直りますが、変換は
`void-function mapc` で止まります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Improved compatibility with older Emacs versions.
  * Improved support for XEmacs event handling and input-method deactivation.
  * Added clearer error messaging when required XEmacs compatibility support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->