### PR TITLE
src-util/anthy-unicode.el: agent との pipe を UTF-8 に固定する

### DIFF
--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -82,6 +82,13 @@
 	 (coding-system-p 'utf-8-unix))
        (= (length (decode-coding-string "\346\227\245" 'utf-8)) 1)))
 
+;; mapc は Emacs 21 から。無い処理系では anthy 9100h と同じ mapcar を
+;; 使う。この行は返り値を捨てるので、どちらでも同じことになる。
+(defvar anthy-mapc-function
+  (if (fboundp 'mapc)
+      'mapc
+    'mapcar))
+
 ;; face
 (defvar anthy-highlight-face nil)
 (defvar anthy-underline-face nil)
@@ -262,7 +269,7 @@
 	(delete-region start (+ start len))
 	(goto-char start)))
   (setq anthy-preedit "")
-  (mapc 'delete-overlay anthy-preedit-overlays)
+  (funcall anthy-mapc-function 'delete-overlay anthy-preedit-overlays)
   (setq anthy-preedit-overlays nil))
 
 (defun anthy-select-face-by-attr (attr)

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -70,6 +70,18 @@
 (defvar anthy-agent-unicode-command-list '("anthy-agent-unicode")
   "anthy-agent-unicodeのPATH 名")
 
+;; utf-8-unix が実際に使えるか。名前が在るだけでは足りない。Emacs 21.4 は
+;; utf-8 という coding system を持っているが、CJK を入れる先が無いので三
+;; byte の漢字が byte のまま残る。一文字復号して長さを見る。
+;; XEmacs の coding-system-p は symbol ではなく coding system の object を
+;; 取るので、symbol で訊くと常に nil になる。XEmacs 側の綴りは
+;; find-coding-system で、GNU Emacs には無い。
+(defun anthy-utf-8-unix-p ()
+  (and (if (fboundp 'find-coding-system)
+	   (find-coding-system 'utf-8-unix)
+	 (coding-system-p 'utf-8-unix))
+       (= (length (decode-coding-string "\346\227\245" 'utf-8)) 1)))
+
 ;; face
 (defvar anthy-highlight-face nil)
 (defvar anthy-underline-face nil)
@@ -753,6 +765,8 @@
 	    (kill-process anthy-agent-unicode-process))
 	(setq anthy-agent-unicode-process proc)
 	(set-process-query-on-exit-flag proc nil)
+	(if (anthy-utf-8-unix-p)
+	    (set-process-coding-system proc 'utf-8-unix 'utf-8-unix))
 ;;	(if anthy-xemacs
 ;;	    (if (coding-system-p (find-coding-system 'euc-japan))
 ;;		(set-process-coding-system proc 'euc-japan 'euc-japan))

--- a/src-util/anthy-unicode.el
+++ b/src-util/anthy-unicode.el
@@ -765,6 +765,14 @@
 	    (kill-process anthy-agent-unicode-process))
 	(setq anthy-agent-unicode-process proc)
 	(set-process-query-on-exit-flag proc nil)
+	;; utf-8 を扱えない処理系では Mule-UCS が在れば読む。実測で扱えな
+	;; かったのは XEmacs 21.4 と Emacs 21.4 と Emacs 20.7 の三つ。
+	;; XEmacs 21.5 と Emacs 22 以降は最初から扱えるので何もしない。
+	;; 無ければ黙って諦める。
+	(if (not (anthy-utf-8-unix-p))
+	    (condition-case nil
+		(require 'un-define)
+	      (error nil)))
 	(if (anthy-utf-8-unix-p)
 	    (set-process-coding-system proc 'utf-8-unix 'utf-8-unix))
 ;;	(if anthy-xemacs


### PR DESCRIPTION
non-UTF-8 環境での使用は優先度が低く、お時間ができたときに評価する、と伺いました。
急ぐ話ではありませんので、お手すきのときにお願いします。

古い emacs で動くようにする対応は予定が無い、とも伺いましたが、Emacs 20 への
対応は一行だけでしたので残してあります。

三本積んでいます。一本目は単独で効きます。二本目と三本目は #21 の六本が
入っていないと効果を確かめられません。それが無いと XEmacs は
`set-process-query-on-exit-flag` で、Emacs 20 は `set-face-underline` で、
agent を起こす前に止まってしまうためです。

```
                   1 pipe   2 Mule-UCS   3 mapc
  Emacs 22 - 31      OK         OK         OK
  XEmacs 21.5.36     OK         OK         OK
  XEmacs 21.4.25     NG         OK         OK
  Emacs 21.4         NG         OK         OK
  Emacs 20.7         NG         NG         OK
```

XEmacs 21.4 と Emacs 21.4 は `utf-8` を扱えないので、一本目だけでは pipe が
変わりません。二本目で Mule-UCS を読んで通ります。Emacs 20.7 はそこまで来ても
`void-function mapc` で変換に届かず、三本目で通ります。

## pipe を UTF-8 に固定

`anthy-agent-unicode` は UTF-8 でしか話しませんが、agent との pipe に符号化を
設定していないので、Emacs の既定 — つまり利用者の locale が使われます。
`src-util/input.c` が `ANTHY_UTF8_ENCODING` を無条件に立てており、`--eucjp` は
`--egg` の protocol にしか届かないので、この elisp からは UTF-8 以外を選べません。

素の Fedora 44 で再現します。当て物も build も要りません。

```
$ LC_ALL=ja_JP.eucjp emacs -Q -batch \
      -L /usr/share/emacs/site-lisp/anthy-unicode -l /tmp/t.el
(japanese-iso-8bit-unix . japanese-iso-8bit-unix)
e6 97 e3 83 a6 9c f5 80 91 91 aa 9e
```

九 byte 返るはずのものが返りません。当てると返ります。

```
(utf-8-unix . utf-8-unix)
e6 97 a5 e6 9c ac e8 aa 9e
```

**日本語の locale だけの話ではありません。** Emacs 30.2 / NetBSD 11.0/amd64 で、
この箱に在る 203 の locale すべてで測りました。

```
  上流      136 で化ける、67 で正しい
  この当て  203 すべて正しい
```

化ける 136 を、pipe に何が立つかで分けるとこうなります。

```
  48  iso-latin-1          de_DE.ISO8859-1 fr_FR.ISO8859-1 など
  31  iso-latin-9
  18  iso-latin-2
   7  cyrillic-iso-8bit
   6  windows-1251
   4  japanese-iso-8bit / japanese-shift-jis   ja ja_JP.eucJP ja_JP.ct ja_JP.SJIS
  22  その他 (中国語 韓国語 ギリシャ語 ヘブライ語など)
```

日本語は 136 のうち 4 です。`de_DE.ISO8859-1` で使っている方も同じように
化けます。

正しく通る 67 は UTF-8 の locale が 62、残る 5 が `en_US.US-ASCII` と
`ja_JP.ISO-2022-JP` 系の四つです。iso-2022-jp は 7bit の escape 方式なので、
agent の UTF-8 出力がそのまま素通りします。どれもこの当てで変わりません。

`-unix` を付けるかどうかで結果が違います。`utf-8` だけだと行末が未定のままに
なり、復号する側が `utf-8-dos` に落ち着きます。

使えるかどうかは二つ確かめています。まず名前です。XEmacs にも
`coding-system-p` は在りますが、受け取るのは symbol ではなく coding system の
object なので、`(coding-system-p 'utf-8-unix)` は XEmacs では常に nil です。
`find-coding-system` が XEmacs 側の綴りで、GNU Emacs には在りません。この file の

```elisp
;;	(if (coding-system-p (find-coding-system 'euc-japan))
```

というコメントアウト行が二重に書いてあるのが答えでした。

名前だけでは足りませんでした。Emacs 21.4 は `utf-8` を持っていますが、CJK を
入れる先が無いので復号できません。それを有効にする `utf-translate-cjk-mode` は
Emacs 22 からで、21.4 には変数すら在りません。

```
Emacs 21.4  (coding-system-p 'utf-8-unix)               t
            (decode-coding-string <漢字一文字> 'utf-8)   長さ 3
Emacs 22.3  同じ二つ                                     t、長さ 1
```

そこで漢字を一文字復号して、長さが 1 になるかを見ています。

「nihongo」を確定したときの結果です。グラフの左が対象、右は参考として測った
だけの版です。

```
  ja_JP.eucJP   31.1  30.2  29.4  28.2 | 27.2  24.5  23.4  22.3
    上流          NG    NG    NG    NG |   NG    NG    NG    NG
    この当て      OK    OK    OK    OK |   OK    OK    OK    OK

  ja_JP.SJIS    31.1  30.2  29.4  28.2 | 27.2  24.5  23.4  22.3
    上流          NG    NG    NG    NG |   NG    NG    NG    NG
    この当て      OK    OK    OK    OK |   OK    OK    OK    OK
```

警告の数はこの当てでは動きません。

## utf-8 を扱えない版への対応

XEmacs 21.4 と Emacs 20.7 には `utf-8` という coding system がありません。
Emacs 21.4 は名前だけ在って復号できません。この三つで Mule-UCS を読みます。
XEmacs は `mule-ucs-1.21-pkg` として、pkgsrc は `editors/mule-ucs` を
Emacs 20/21 用に持っています。

```
LC_ALL=ja_JP.eucJP で「nihongo」を確定
  XEmacs 21.4.25  一本目まで  pipe (shift_jis-dos . binary)、化けたまま
                  二本目まで  pipe (utf-8-unix . utf-8-unix)、日本語
  Emacs 21.4      一本目まで  pipe (japanese-iso-8bit-dos . japanese-iso-8bit)
                  二本目まで  pipe (utf-8-unix . utf-8-unix)、日本語
```

既に扱える版では何もしません。XEmacs 21.5.36 と Emacs 22 以降がそれです。
Mule-UCS が入っていなければ `require` の signal を捕まえて、agent はそのまま
起こします。`require` は使う場所に置いてあるので、agent を起こさない session は
読み込みません。

利用者が自分で Mule-UCS を読んでおけば、この二本目が無くても同じ結果になります。
そちらで足りるとお考えでしたら、この一本は落としてください。

## Emacs 20 への対応

#21 と上の二本まで来たところで、残る壁は `mapc` の呼び出し一行だけでした。
試しに加えたところ、他に影響することなく動きました。

要らなければこの一本は落としてください。#21 にて tag を付ける案をいただいて
いましたので、そちらで済ませる形でも構いません。

```
Emacs 20.7
  #21 + pipe + Mule-UCS            void-function mapc
  #21 + pipe + Mule-UCS + この一本  「nihongo」が 日本語 になる
```

この一本の有無だけを変えて、Emacs 21.4 から 31.1 までと XEmacs 21.4.25 /
21.5.36 で、警告の数・undo・input method からの離脱・下線・pipe の符号化を
測りました。どれも両方で同じ値です。

`mapc` は Emacs 21 からで、持たないのは Emacs 20.7 だけでした。XEmacs 21.4.25 も
21.5.36 も、Emacs 21.4 以降も持っています。anthy 9100h はこの行で `mapcar` を
使っていました。返り値は捨てるので、どちらでも同じことになります。

変更は呼び出しのその一行と、名前を選ぶ defvar 一つです。
